### PR TITLE
Add more search support - BREAKING CHANGE

### DIFF
--- a/player.go
+++ b/player.go
@@ -69,7 +69,6 @@ func (a *API) GetDevices() ([]*Device, error) {
 
 // Play starts a new context or resume current playback on the user's active device.
 // https://developer.spotify.com/documentation/web-api/reference/#endpoint-start-a-users-playback
-// contextURI added to allow for album and playlist support - A blank context uri will play just the track uri.
 func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 	v := make(url.Values)
 	if deviceID != "" {
@@ -77,9 +76,9 @@ func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 	}
 
 	body := &struct {
-		ContextURIs string `json:"context_uri,omitempty"`
-		URIs []string `json:"uris,omitempty"`
-	}{ContextURIs: contextURI,URIs: uris}
+		ContextURIs string   `json:"context_uri,omitempty"`
+		URIs        []string `json:"uris,omitempty"`
+	}{ContextURIs: contextURI, URIs: uris}
 
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -87,7 +86,6 @@ func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 	}
 
 	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
-
 }
 
 // Pause pauses playback on the user's account.

--- a/player.go
+++ b/player.go
@@ -80,17 +80,33 @@ func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 		return a.put("v1", "/me/player/play", v, nil)
 	}
 
-	body := &struct {
-		ContextURIs string `json:"context_uri"`
-		URIs []string `json:"uris"`
-	}{ContextURIs: contextURI,URIs: uris}
+	// If I don't put the return into the if statement the IDE states that the body struct will not be used and returned?
+	if contextURI != "" {
+		body := &struct {
+			ContextURIs string `json:"context_uri"`
+		}{ContextURIs: contextURI}
 
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+
+		return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
+
+	} else if len(uris) > 0 {
+		body := &struct {
+			URIs []string `json:"uris"`
+		}{URIs: uris}
+
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+
+		return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
+
 	}
-
-	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
+	return a.put("v1", "/me/player/play", v, nil)
 }
 
 // Pause pauses playback on the user's account.

--- a/player.go
+++ b/player.go
@@ -140,3 +140,55 @@ func (a *API) Queue(uri string) error {
 
 	return a.post("v1", "/me/player/queue", v, nil)
 }
+
+// PlayPlaylist sets the playback on a playlist context and not a single song uri.
+// https://community.spotify.com/t5/Spotify-for-Developers/API-is-there-a-way-to-start-playing-a-playlist-from-a-specific/m-p/4977046#M509
+// https://stackoverflow.com/questions/48532890/spotify-web-api-play-endpoint-play-track
+func (a *API) PlayPlaylist(deviceID, playlistURI string) error {
+
+	v := make(url.Values)
+	if deviceID != "" {
+		v.Add("device_id", deviceID)
+	}
+
+	if len(playlistURI) == 0{
+		return a.put("v1", "/me/player/play", v, nil)
+	}
+
+
+	body := &struct {
+		URIs string `json:"context_uri"`
+	}{URIs: playlistURI}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
+}
+
+// PlayAlbum sets the playback on an album context and not a single song uri. This function is very similar to PlayPlaylist
+// https://community.spotify.com/t5/Spotify-for-Developers/API-is-there-a-way-to-start-playing-a-playlist-from-a-specific/m-p/4977046#M509
+// TODO: Add more documentation here - This is insufficient
+func (a *API) PlayAlbum(deviceID, albumURI string) error {
+	v := make(url.Values)
+	if deviceID != "" {
+		v.Add("device_id", deviceID)
+	}
+
+	if len(albumURI) == 0{
+		return a.put("v1", "/me/player/play", v, nil)
+	}
+
+	body := &struct {
+		URIs string `json:"context_uri"`
+	}{URIs: albumURI}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
+}

--- a/player.go
+++ b/player.go
@@ -69,19 +69,21 @@ func (a *API) GetDevices() ([]*Device, error) {
 
 // Play starts a new context or resume current playback on the user's active device.
 // https://developer.spotify.com/documentation/web-api/reference/#endpoint-start-a-users-playback
-func (a *API) Play(deviceID string, uris ...string) error {
+// contextURI added to allow for album and playlist support - A blank context uri will play just the track uri.
+func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 	v := make(url.Values)
 	if deviceID != "" {
 		v.Add("device_id", deviceID)
 	}
 
-	if len(uris) == 0 {
+	if (len(uris) == 0) && (len(contextURI) == 0) {
 		return a.put("v1", "/me/player/play", v, nil)
 	}
 
 	body := &struct {
+		ContextURIs string `json:"context_uri"`
 		URIs []string `json:"uris"`
-	}{URIs: uris}
+	}{ContextURIs: contextURI,URIs: uris}
 
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -139,56 +141,4 @@ func (a *API) Queue(uri string) error {
 	v.Add("uri", uri)
 
 	return a.post("v1", "/me/player/queue", v, nil)
-}
-
-// PlayPlaylist sets the playback on a playlist context and not a single song uri.
-// https://community.spotify.com/t5/Spotify-for-Developers/API-is-there-a-way-to-start-playing-a-playlist-from-a-specific/m-p/4977046#M509
-// https://stackoverflow.com/questions/48532890/spotify-web-api-play-endpoint-play-track
-func (a *API) PlayPlaylist(deviceID, playlistURI string) error {
-
-	v := make(url.Values)
-	if deviceID != "" {
-		v.Add("device_id", deviceID)
-	}
-
-	if len(playlistURI) == 0{
-		return a.put("v1", "/me/player/play", v, nil)
-	}
-
-
-	body := &struct {
-		URIs string `json:"context_uri"`
-	}{URIs: playlistURI}
-
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
-}
-
-// PlayAlbum sets the playback on an album context and not a single song uri. This function is very similar to PlayPlaylist
-// https://community.spotify.com/t5/Spotify-for-Developers/API-is-there-a-way-to-start-playing-a-playlist-from-a-specific/m-p/4977046#M509
-// TODO: Add more documentation here - This is insufficient
-func (a *API) PlayAlbum(deviceID, albumURI string) error {
-	v := make(url.Values)
-	if deviceID != "" {
-		v.Add("device_id", deviceID)
-	}
-
-	if len(albumURI) == 0{
-		return a.put("v1", "/me/player/play", v, nil)
-	}
-
-	body := &struct {
-		URIs string `json:"context_uri"`
-	}{URIs: albumURI}
-
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
 }

--- a/player.go
+++ b/player.go
@@ -76,37 +76,18 @@ func (a *API) Play(deviceID, contextURI string, uris ...string) error {
 		v.Add("device_id", deviceID)
 	}
 
-	if (len(uris) == 0) && (len(contextURI) == 0) {
-		return a.put("v1", "/me/player/play", v, nil)
+	body := &struct {
+		ContextURIs string `json:"context_uri,omitempty"`
+		URIs []string `json:"uris,omitempty"`
+	}{ContextURIs: contextURI,URIs: uris}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
 	}
 
-	// If I don't put the return into the if statement the IDE states that the body struct will not be used and returned?
-	if contextURI != "" {
-		body := &struct {
-			ContextURIs string `json:"context_uri"`
-		}{ContextURIs: contextURI}
+	return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
 
-		data, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-
-		return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
-
-	} else if len(uris) > 0 {
-		body := &struct {
-			URIs []string `json:"uris"`
-		}{URIs: uris}
-
-		data, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-
-		return a.put("v1", "/me/player/play", v, bytes.NewReader(data))
-
-	}
-	return a.put("v1", "/me/player/play", v, nil)
 }
 
 // Pause pauses playback on the user's account.

--- a/search.go
+++ b/search.go
@@ -7,10 +7,10 @@ import (
 
 // Search gets Spotify Catalog information about albums, artists, playlists, tracks, shows or episodes that match a
 // keyword string.
-func (a *API) Search(q string, limit int) (*Paging, error) {
+func (a *API) Search(q, searchType  string, limit int) (*Paging, error) {
 	v := url.Values{}
 	v.Add("q", q)
-	v.Add("type", "track")
+	v.Add("type", searchType)
 	v.Add("limit", strconv.Itoa(limit))
 
 	paging := new(Paging)


### PR DESCRIPTION
Is required for this issue: [spotify-cli #40](https://github.com/brianstrauch/spotify-cli/issues/40)

Changed the api.Search() function to take in an additional paramater of 'searchType)

FROM: 
`Search(q string, limit int)`
TO:
`Search(q, searchType  string, limit int)`

This will cause all the functionality within [spotify-cli](https://github.com/brianstrauch/spotify-cli ) that uses the api.Search() to fail as it will require an additional parameter of 'tracks' to beadded

---

I have realised this included the changes from PR#4 accidentally - Do I need to remove this?