### PR TITLE
Added album searching and paging objects as they are different than t…

### DIFF
--- a/album.go
+++ b/album.go
@@ -1,10 +1,5 @@
 package spotify
 
-import (
-	"net/url"
-	"strconv"
-)
-
 // Album represents an AlbumObject in the Spotify API
 // https://developer.spotify.com/documentation/web-api/reference/#object-albumobject
 type Album struct {
@@ -19,29 +14,4 @@ type Album struct {
 	TotalTracks          int       `json:"total_tracks"`
 	Tracks               TrackPage `json:"tracks"`
 	Name                 string    `json:"name"`
-}
-
-// SearchAlbum returns a AlbumPaging object that includes a number of albums as per the limit set
-func (a *API) SearchAlbum(q, searchType string, limit int) (*PagingAlbums, error) {
-	v := url.Values{}
-	v.Add("q", q)
-	v.Add("type", searchType)
-	v.Add("limit", strconv.Itoa(limit))
-
-	pagingAlbums := new(PagingAlbums)
-	err := a.get("v1", "/search", v, pagingAlbums)
-
-	return pagingAlbums, err
-}
-
-func (a *API) GetAlbum(name string) (*Album, error) {
-
-	pagingAlbums, err := a.SearchAlbum(name, "album", 1)
-	if err != nil {
-		return nil, err
-	}
-
-	album := pagingAlbums.Albums.Items
-
-	return album[0], nil
 }

--- a/album.go
+++ b/album.go
@@ -1,6 +1,9 @@
 package spotify
 
-import "time"
+import (
+	"net/url"
+	"strconv"
+)
 
 // Album represents an AlbumObject in the Spotify API
 // https://developer.spotify.com/documentation/web-api/reference/#object-albumobject
@@ -11,9 +14,34 @@ type Album struct {
 	Images               []Image   `json:"images"`
 	Label                string    `json:"label"`
 	Popularity           int       `json:"popularity"`
-	ReleaseDate          time.Time `json:"release_date"`
+	ReleaseDate          string    `json:"release_date"`
 	ReleaseDatePrecision string    `json:"release_date_precision"`
 	TotalTracks          int       `json:"total_tracks"`
 	Tracks               TrackPage `json:"tracks"`
 	Name                 string    `json:"name"`
+}
+
+// SearchAlbum returns a AlbumPaging object that includes a number of albums as per the limit set
+func (a *API) SearchAlbum(q, searchType string, limit int) (*PagingAlbums, error) {
+	v := url.Values{}
+	v.Add("q", q)
+	v.Add("type", searchType)
+	v.Add("limit", strconv.Itoa(limit))
+
+	pagingAlbums := new(PagingAlbums)
+	err := a.get("v1", "/search", v, pagingAlbums)
+
+	return pagingAlbums, err
+}
+
+func (a *API) GetAlbum(name string) (*Album, error) {
+
+	pagingAlbums, err := a.SearchAlbum(name, "album", 1)
+	if err != nil {
+		return nil, err
+	}
+
+	album := pagingAlbums.Albums.Items
+
+	return album[0], nil
 }

--- a/paging.go
+++ b/paging.go
@@ -3,6 +3,7 @@ package spotify
 // Paging represents a PagingObject in the Spotify API
 // https://developer.spotify.com/documentation/web-api/reference/#object-pagingobject
 type Paging struct {
+	Albums AlbumPage `json:"albums"`
 	Tracks TrackPage `json:"tracks"`
 }
 
@@ -19,11 +20,6 @@ type PlaylistPage struct {
 type PlaylistTrackPage struct {
 	PagingMeta
 	Items []*PlaylistTrack `json:"items"`
-}
-
-// PagingAlbums represents an PagingObject in the spotify API for albums
-type PagingAlbums struct {
-	Albums AlbumPage `json:"albums"`
 }
 
 type AlbumPage struct {

--- a/paging.go
+++ b/paging.go
@@ -20,3 +20,13 @@ type PlaylistTrackPage struct {
 	PagingMeta
 	Items []*PlaylistTrack `json:"items"`
 }
+
+// PagingAlbums represents an PagingObject in the spotify API for albums
+type PagingAlbums struct {
+	Albums AlbumPage `json:"albums"`
+}
+
+type AlbumPage struct {
+	PagingMeta
+	Items []*Album `json:"items"`
+}


### PR DESCRIPTION
As they are different than Tracks but same endpoint.
Had to change the field:
```
ReleaseDate from time.Time to string. 
```
it was of a weird time syntax that I had not seen before and was not automatically transformed

searchAlbums is not hardcoded for type. It probably could be.